### PR TITLE
Fix some ES Module Parser path resolving bugs

### DIFF
--- a/www/modloader/early_loader.js
+++ b/www/modloader/early_loader.js
@@ -130,7 +130,7 @@
                 resolveId: (source, importer) => {
                     if (importer) {
                         const { fingerprint, filename } = ESModuleParser.parseRollupFileId(importer);
-                        if (fingerprint && filename) return ESModuleParser.buildRollupFileId(fingerprint, path.relative(path.dirname(filename), source));
+                        if (fingerprint && filename) return ESModuleParser.buildRollupFileId(fingerprint, path.join(path.dirname(filename), source));
                     } else if (ESModuleParser.parseRollupFileId(source).filename) {
                         return source;
                     }
@@ -152,7 +152,8 @@
         }
 
         static buildRollupFileId(fingerprint, filename) {
-            return `${fingerprint}:${filename}`;
+            const extension = path.extname(filename);
+            return `${fingerprint}:${filename}${extension ? "" : ".js"}`;
         }
 
         static parseRollupFileId(id) {


### PR DESCRIPTION
* Should use `path.join` instead of `path.relative` to make `..` paths work.
* Support resolving paths that don't have explicit `.js` extension.

We should at some point do more work to support:
* `index.js` files.
* Smarter auto-file-extension resolving; supporting `.mjs` vs `.js`, for example.