### PR TITLE
ESM Async Exec

### DIFF
--- a/www/modloader/early_loader.js
+++ b/www/modloader/early_loader.js
@@ -148,8 +148,11 @@
         }
 
         static bufferFromGeneratedCode(generatedCode, useIIFE) {
-            const wrappedCode = `${useIIFE ? "(function(){" : ""}${generatedCode}${useIIFE ? "})()" : ""}`;
-            return Buffer.from(wrappedCode);
+            const wrappedCode = `(function(){${generatedCode}})()`;
+            if (useIIFE)
+                return Buffer.from(wrappedCode);
+            else
+                return Buffer.from(generatedCode);
         }
 
         static buildRollupFileId(fingerprint, filename) {

--- a/www/modloader/early_loader.js
+++ b/www/modloader/early_loader.js
@@ -377,7 +377,7 @@
                 for (let { file: file_name, runat } of this.json.asyncExec) {
                     let fileData = await _read_file(await this.resolveDataSource(file_name));
                     if (runat === "when_discovered") {
-                        if (file.endsWith(".mjs")) {
+                        if (file_name.endsWith(".mjs")) {
                             $modLoader.$log("[ERROR] Cannot have ES Modules in when_discovered");
                             alert(`AsyncExec: Cannot use when_discovered with ESM, @${this.json.id}:${file_name}`);
                             continue;

--- a/www/modloader/early_loader.js
+++ b/www/modloader/early_loader.js
@@ -405,7 +405,8 @@
                                 }
                             });
                             let ds = await mf.resolveDataSource();
-                            console.log(ds);
+                            fileData = await _read_file(ds);
+                            data = fileData.toString("utf-8");
                         }
                         $modLoader.$execScripts[runat].push({
                             data, req


### PR DESCRIPTION
This patchset adds:
- Extra configuration options into the mod parser (defaults to `{}` on this.config)
- The ability to disable the emission of IIFEs around ESModuleParser output. Not exposed to the users, used in async_exec.
- The ability to use ES Modules in async_exec if the file extension is `.mjs`